### PR TITLE
fixed metric reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2023-12-13
+### Fixed
+- `to_processing` metric using wrong `updated_at`.
+
 ## [0.1.0] - 2023-12-04
 ### Added
 - Initial rework of relay-rs(v1) https://github.com/rust-playground/relay-rs with real world improvements after using in production for over a year.
 
-[Unreleased]: https://github.com/relay-io/relay/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/relay-io/relay/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/relay-io/relay/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/relay-io/relay/compare/70cfed7...v0.1.0

--- a/relay-postgres/src/postgres.rs
+++ b/relay-postgres/src/postgres.rs
@@ -353,7 +353,7 @@ impl PgStore {
                          j.run_at,
                          j.updated_at,
                          j.created_at,
-                         subquery.updated_at
+                         subquery.updated_at as subquery_updated_at
             ",
             )
             .await?;


### PR DESCRIPTION
## PR

This corrects the `run_at` -> `updated_at` metric reporting for `to_processing` metric.